### PR TITLE
メディアクエリという苦肉の策が不要になったので文字サイズ係数を増加

### DIFF
--- a/src/lib_js/fit.js
+++ b/src/lib_js/fit.js
@@ -2,7 +2,7 @@
 
 //ウィンドウサイズに応じてフォントサイズを変更
 function fit(){
-	$ID("gaku-ura_base").style.fontSize = Math.max(12, Math.min(window.innerHeight*0.02, window.innerWidth*0.02))+"px";
+	$ID("gaku-ura_base").style.fontSize = Math.max(12, Math.min(window.innerHeight*0.03, window.innerWidth*0.03))+"px";
 }
 fit();
 window.addEventListener("resize", fit);


### PR DESCRIPTION
文字サイズを画面の大きさによって変更する方法が、縦横両方で加味されるようになり、メディアクエリでごまかす必要がなくなったので、当初の文字サイズ係数に戻す。